### PR TITLE
fix: address 5 critical production blockers

### DIFF
--- a/.sisyphus/boulder.json
+++ b/.sisyphus/boulder.json
@@ -4,7 +4,8 @@
   "session_ids": [
     "ses_3285c02ebffeP6bJHKbxw73Xom",
     "ses_current",
-    "ses_323e6acb5ffeW3qt33wXlXhvu0"
+    "ses_323e6acb5ffeW3qt33wXlXhvu0",
+    "ses_31d5d5069ffeu0cuiYmZ6NYFgM"
   ],
   "plan_name": "phase2-production-readiness",
   "agent": "atlas",

--- a/control-plane/fractal-gateway-ebpf/src/quota.rs
+++ b/control-plane/fractal-gateway-ebpf/src/quota.rs
@@ -242,9 +242,29 @@ pub struct ProbeContext {
 }
 
 impl ProbeContext {
-    fn arg<T>(&self, n: usize) -> Option<T> {
-        // Simplified argument extraction
-        None
+    /// Extract syscall argument from pt_regs
+    ///
+    /// # Safety
+    /// Requires valid pt_regs pointer from eBPF probe context
+    unsafe fn arg<T: Copy>(&self, n: usize) -> Option<T> {
+        if self.regs.is_null() {
+            return None;
+        }
+
+        // x86_64: arguments are in rdi, rsi, rdx, rcx, r8, r9 (indices 0-5)
+        // For syscalls, orig_rax holds the syscall number, then args follow
+        // Note: pt_regs field names depend on the architecture
+        let arg_ptr = match n {
+            0 => core::ptr::addr_of!((*self.regs).di),
+            1 => core::ptr::addr_of!((*self.regs).si),
+            2 => core::ptr::addr_of!((*self.regs).dx),
+            3 => core::ptr::addr_of!((*self.regs).cx),
+            4 => core::ptr::addr_of!((*self.regs).r8),
+            5 => core::ptr::addr_of!((*self.regs).r9),
+            _ => return None,
+        };
+
+        Some(core::ptr::read(arg_ptr as *const T))
     }
 }
 
@@ -253,7 +273,31 @@ pub struct LsmContext {
     // LSM context
 }
 
-// Placeholder for bpf_ktime_get_ns
+/// Get current time in nanoseconds from eBPF helper
+///
+/// # Safety
+/// This is safe to call from eBPF programs as it uses the bpf_ktime_get_ns kernel helper
 unsafe fn bpf_ktime_get_ns() -> u64 {
-    0 // Placeholder
+    // Use aya_ebpf::helpers::bpf_ktime_get_ns if available, otherwise implement via inline asm
+    #[cfg(target_arch = "bpf")]
+    {
+        // On BPF target, use the actual eBPF helper
+        // Helper number 5 is bpf_ktime_get_ns
+        let time_ns: u64;
+        core::arch::asm!(
+            "call 5",
+            out("r0") time_ns,
+            options(nomem, nostack, preserves_flags)
+        );
+        time_ns
+    }
+
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        // For testing on non-BPF targets, return a monotonic counter
+        // In production, this should never be reached
+        use core::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
 }

--- a/control-plane/fractal-gateway/src/main.rs
+++ b/control-plane/fractal-gateway/src/main.rs
@@ -41,7 +41,10 @@ async fn main() -> Result<(), anyhow::Error> {
         warn!("failed to initialize eBPF logger: {}", e);
     }
 
-    let program: &mut Xdp = bpf.program_mut("fractal_gateway").unwrap().try_into()?;
+    let program: &mut Xdp = bpf
+        .program_mut("fractal_gateway")
+        .context("failed to find eBPF program 'fractal_gateway' - ensure the eBPF code is compiled")?
+        .try_into()?;
     program.load()?;
     program.attach(&opt.iface, XdpFlags::default())
         .context("failed to attach the XDP program with default flags")?;
@@ -51,7 +54,10 @@ async fn main() -> Result<(), anyhow::Error> {
     // -----------------------------------------------------
     // Dynamic BPF Map Manipulation (Rule Injection)
     // -----------------------------------------------------
-    let mut blocked_ips: HashMap<_, u32, u8> = HashMap::try_from(bpf.map_mut("BLOCKED_IPS").unwrap())?;
+    let mut blocked_ips: HashMap<_, u32, u8> = HashMap::try_from(
+        bpf.map_mut("BLOCKED_IPS")
+            .context("failed to find eBPF map 'BLOCKED_IPS' - ensure the eBPF code is compiled")?,
+    )?;
     
     // Example: Block IP 192.168.1.100 (in network-byte order)
     let malicious_ip: u32 = u32::from_be_bytes([192, 168, 1, 100]);

--- a/control-plane/state-engine/src/engine.rs
+++ b/control-plane/state-engine/src/engine.rs
@@ -14,6 +14,8 @@ pub enum EngineError {
     Postgres(#[from] sqlx::Error),
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
+    #[error("Database migration error: {0}")]
+    Migration(String),
 }
 
 /// Durable State Engine
@@ -34,7 +36,7 @@ impl StateEngine {
         sqlx::migrate!("./migrations")
             .run(&pg_pool)
             .await
-            .expect("Failed to execute database migrations");
+            .map_err(|e| EngineError::Migration(e.to_string()))?;
 
         Ok(Self {
             redis_client,

--- a/orchestration/manager/main.go
+++ b/orchestration/manager/main.go
@@ -61,6 +61,7 @@ func (dm *DAGManager) Execute() error {
 
 	readyQueue := make(chan *TaskNode, len(dm.Nodes))
 	completionChan := make(chan string, len(dm.Nodes))
+	dispatcherDone := make(chan struct{})
 	var wg sync.WaitGroup
 
 	// 1. Enqueue all initial nodes with 0 in-degree
@@ -77,6 +78,7 @@ func (dm *DAGManager) Execute() error {
 
 	// 2. Dispatch loop
 	go func() {
+		defer close(dispatcherDone)
 		for {
 			select {
 			case task := <-readyQueue:
@@ -118,10 +120,9 @@ func (dm *DAGManager) Execute() error {
 		}
 	}()
 
+	// Wait for dispatcher to finish (all tasks completed)
+	<-dispatcherDone
 	// Wait for all actual worker routines to finish
-	// (in a real scenario we'd track the overarching DAG finish)
-	// We use sleep here to let the dispatch daemon finish for the demo.
-	time.Sleep(2 * time.Second)
 	wg.Wait()
 	return nil
 }

--- a/plugins/marketplace/src/store.rs
+++ b/plugins/marketplace/src/store.rs
@@ -75,7 +75,7 @@ impl MarketplaceStore {
     }
 
     /// Install plugin from cache
-    pub fn install(
+    pub async fn install(
         &self,
         entry: &MarketplaceEntry,
     ) -> Result<std::path::PathBuf, MarketplaceError> {


### PR DESCRIPTION
- plugins/marketplace: change install() to async fn for tokio::fs compatibility
- state-engine: add Migration error variant, replace .expect() with .map_err()
- fractal-gateway: replace .unwrap() with .context() for better error messages
- fractal-gateway-ebpf: implement arg<T>() extraction and bpf_ktime_get_ns()
- orchestration/manager: replace time.Sleep hack with dispatcherDone channel